### PR TITLE
Fix for .wadl without full schema definitions

### DIFF
--- a/lib/serializer/angular5-ts/service-method.ejs
+++ b/lib/serializer/angular5-ts/service-method.ejs
@@ -10,7 +10,11 @@
         responseType = 'string';
         break;
       case 'application/json':
-        responseType = method.responseType;
+        if (method.responseType) {
+          responseType = method.responseType;
+        } else {
+          responseType = 'any';
+        }
         break;
       case 'application/octet-stream':
         responseType = 'File';

--- a/lib/serializer/angular5-ts/service-method.ejs
+++ b/lib/serializer/angular5-ts/service-method.ejs
@@ -10,11 +10,7 @@
         responseType = 'string';
         break;
       case 'application/json':
-        if (method.responseType) {
-          responseType = method.responseType;
-        } else {
-          responseType = 'any';
-        }
+        responseType = method.responseType || 'any';
         break;
       case 'application/octet-stream':
         responseType = 'File';


### PR DESCRIPTION
Some .wadl files do not include fill schema definitions and response types of methods.

They do not have grammars nor any `.xsd` file for example:

https://campus.cs.le.ac.uk/tyche/CO7214Rest3/rest/application.wadl

In that case, currently the library generates a file with errors for angular5 like below:

```typescript
public submitMostActiveFollowed(passCode: string, userName: string, activeUser: string): Observable<> {
  ...
}
```

Where `Observable` can not have an empty argument inside `<>`.

This fix will detect if the method actually has a `responseType` and it will set it, otherwise it will set it to `any` fixing the missing argument error inside observable.